### PR TITLE
[EXOD-009] Fix claim and stake - OPTION 1

### DIFF
--- a/contracts/StakingHelper.sol
+++ b/contracts/StakingHelper.sol
@@ -82,8 +82,7 @@ interface IERC20 {
 }
 
 interface IStaking {
-  function stake(uint256 _amount, address _recipient) external returns (bool);
-
+  function stake(uint _amount, address _recipient) external returns (bool);
   function claim(address _recipient) external;
 }
 
@@ -98,10 +97,10 @@ contract StakingHelper {
     OHM = _OHM;
   }
 
-  function stake(uint256 _amount) external {
+  function stake(uint _amount, address _recipient) external {
     IERC20(OHM).transferFrom(msg.sender, address(this), _amount);
     IERC20(OHM).approve(staking, _amount);
-    IStaking(staking).stake(_amount, msg.sender);
-    IStaking(staking).claim(msg.sender);
+    IStaking(staking).stake(_amount, _recipient);
+    IStaking(staking).claim(_recipient);
   }
 }


### PR DESCRIPTION
**NOTE:** this PR isn't a direct copy of the contract, it has been refactored to show what is actually different (not much). The other changes which i took out are simply tabs/spaces line breaks etc. For a full 100% copy you can view [this alternative PR](https://github.com/ExodiaFinance/exodia-contracts/pull/2)

## The probelm
Our stakingHelper.sol contract is uploaded with a stake method which only accepts a single param (amount).

It has been proven that this should have 2 params (amount and recipient).

The olympusDao staking helper which is currently live and in use is [here](https://etherscan.io/address/0xa55ce3e25bd4cb6c5375aa393335b708db790915#code). The stake function here accepts these two params, whereas on the github it does not.

It should be noted that this is the active staking helper for the DAI and ETH bond contracts - I didn't verify other contracts.

## The fix
Copy the staking contract from etherscan and upload here. It can be assumed that this contract has been audited and the github diff changes you see in this PR are minimal so we should be able to assume it will work but good care must be taken to upload the contract correctly to the blockchain and change our bonds to use this staking helper.
