### PR TITLE
[EXOD-009] Fix claim and stake - OPTION 2

### DIFF
--- a/contracts/StakingHelper.sol
+++ b/contracts/StakingHelper.sol
@@ -1,9 +1,17 @@
+/**
+ *Submitted for verification at Etherscan.io on 2021-06-20
+*/
+
+/**
+ *Submitted for verification at Etherscan.io on 2021-06-12
+*/
+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity 0.7.5;
 
-interface IERC20 {
-  function decimals() external view returns (uint8);
 
+interface IERC20 {
+    function decimals() external view returns (uint8);
   /**
    * @dev Returns the amount of tokens in existence.
    */
@@ -30,10 +38,7 @@ interface IERC20 {
    *
    * This value changes when {approve} or {transferFrom} are called.
    */
-  function allowance(address owner, address spender)
-    external
-    view
-    returns (uint256);
+  function allowance(address owner, address spender) external view returns (uint256);
 
   /**
    * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
@@ -60,11 +65,7 @@ interface IERC20 {
    *
    * Emits a {Transfer} event.
    */
-  function transferFrom(
-    address sender,
-    address recipient,
-    uint256 amount
-  ) external returns (bool);
+  function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
 
   /**
    * @dev Emitted when `value` tokens are moved from one account (`from`) to
@@ -82,26 +83,26 @@ interface IERC20 {
 }
 
 interface IStaking {
-  function stake(uint256 _amount, address _recipient) external returns (bool);
-
-  function claim(address _recipient) external;
+    function stake( uint _amount, address _recipient ) external returns ( bool );
+    function claim( address _recipient ) external;
 }
 
 contract StakingHelper {
-  address public immutable staking;
-  address public immutable OHM;
 
-  constructor(address _staking, address _OHM) {
-    require(_staking != address(0));
-    staking = _staking;
-    require(_OHM != address(0));
-    OHM = _OHM;
-  }
+    address public immutable staking;
+    address public immutable OHM;
 
-  function stake(uint256 _amount) external {
-    IERC20(OHM).transferFrom(msg.sender, address(this), _amount);
-    IERC20(OHM).approve(staking, _amount);
-    IStaking(staking).stake(_amount, msg.sender);
-    IStaking(staking).claim(msg.sender);
-  }
+    constructor ( address _staking, address _OHM ) {
+        require( _staking != address(0) );
+        staking = _staking;
+        require( _OHM != address(0) );
+        OHM = _OHM;
+    }
+
+    function stake( uint _amount, address _recipient ) external {
+        IERC20( OHM ).transferFrom( msg.sender, address(this), _amount );
+        IERC20( OHM ).approve( staking, _amount );
+        IStaking( staking ).stake( _amount, _recipient );
+        IStaking( staking ).claim( _recipient );
+    }
 }


### PR DESCRIPTION
**NOTE:** this PR **is** a direct copy of the contract, If you want to view a more clean PR which removes all the spaces/tabs/linebreak changes, view [OPTION 1](https://github.com/ExodiaFinance/exodia-contracts/pull/1)

## The probelm
Our stakingHelper.sol contract is uploaded with a stake method which only accepts a single param (amount).

It has been proven that this should have 2 params (amount and recipient).

The olympusDao staking helper which is currently live and in use is [here](https://etherscan.io/address/0xa55ce3e25bd4cb6c5375aa393335b708db790915#code). The stake function here accepts these two params, whereas on the github it does not.

It should be noted that this is the active staking helper for the DAI and ETH bond contracts - I didn't verify other contracts.

## The fix
Copy the staking contract from etherscan and upload here. It can be assumed that this contract has been audited and the github diff changes you see in this PR are minimal so we should be able to assume it will work but good care must be taken to upload the contract correctly to the blockchain and change our bonds to use this staking helper.
